### PR TITLE
feat: add magentic one multi-agent flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Rename this file to .env and fill in your own keys
+OPENAI_API_KEY=your_openai_api_key
+LS_API_KEY=your_langchain_api_key
+MODEL_NAME=gpt-5-2025-08-07
+BIG_MODEL_NAME=gpt-5-2025-08-07

--- a/Magentic-One.py
+++ b/Magentic-One.py
@@ -1,0 +1,63 @@
+import os
+import config
+from config import MODEL_NAME, BIG_MODEL_NAME
+from autogen import AssistantAgent, UserProxyAgent, GroupChat, GroupChatManager
+from langchain_community.tools.ddg_search import DuckDuckGoSearchRun
+
+search = DuckDuckGoSearchRun()
+
+config_list = [{"model": MODEL_NAME, "api_key": os.getenv("OPENAI_API_KEY") or ""}]
+big_config_list = [{"model": BIG_MODEL_NAME, "api_key": os.getenv("OPENAI_API_KEY") or ""}]
+
+planner = AssistantAgent(
+    "Planner",
+    system_message="""You are a planner. Break the user request into research steps and request help from Researcher and Writer.""",
+    llm_config={"config_list": big_config_list},
+)
+
+researcher = AssistantAgent(
+    "Researcher",
+    system_message="""You gather information using the web_search tool and summarize findings for Writer.""",
+    llm_config={"config_list": config_list},
+)
+
+writer = AssistantAgent(
+    "Writer",
+    system_message="""You compose the final answer for the user using the gathered research.""",
+    llm_config={"config_list": config_list},
+)
+
+critic = AssistantAgent(
+    "Critic",
+    system_message="""Review the Writer's answer for accuracy and completeness before termination.""",
+    llm_config={"config_list": big_config_list},
+)
+
+user = UserProxyAgent(
+    "User",
+    human_input_mode="NEVER",
+    code_execution_config=False,
+)
+
+
+def web_search(query: str) -> str:
+    """Use DuckDuckGo to search the web and return the results."""
+    return search.run(query)
+
+
+researcher.register_function({"web_search": web_search})
+
+groupchat = GroupChat(
+    agents=[user, planner, researcher, writer, critic],
+    messages=[],
+    max_round=12,
+)
+
+manager = GroupChatManager(groupchat=groupchat, llm_config={"config_list": config_list})
+
+
+if __name__ == "__main__":
+    user.initiate_chat(
+        manager,
+        message="Provide a short profile of the 2024 Australian Open singles champions and their hometowns.",
+    )

--- a/Plan-and-execute.py
+++ b/Plan-and-execute.py
@@ -1,5 +1,4 @@
 import operator
-import os
 import warnings
 from typing import Annotated, Tuple, List, TypedDict
 
@@ -13,11 +12,10 @@ from langchain_core.pydantic_v1 import BaseModel, Field
 from langchain_openai import ChatOpenAI
 from langgraph.graph import StateGraph, END
 from langgraph.prebuilt import create_agent_executor
+import config
+from config import MODEL_NAME, BIG_MODEL_NAME
 
 warnings.filterwarnings("ignore")
-os.environ["LANGCHAIN_TRACING_V2"] = "true"
-os.environ["LANGCHAIN_API_KEY"] = os.getenv("LS_API_KEY")
-os.environ["LANGCHAIN_PROJECT"] = "Agents"
 
 # Define tools
 search = TavilySearchResults(max_results=1)
@@ -25,9 +23,9 @@ tools = [search]
 
 # Define Execution Agent
 prompt = hub.pull("hwchase17/openai-functions-agent")
-llm = ChatOpenAI(model="gpt-3.5-turbo")
+llm = ChatOpenAI(model=MODEL_NAME)
 
-big_llm = ChatOpenAI(model="gpt-4-turbo-preview")
+big_llm = ChatOpenAI(model=BIG_MODEL_NAME)
 
 agent_runnable = create_openai_functions_agent(llm=llm, tools=tools, prompt=prompt)
 

--- a/ReAct.py
+++ b/ReAct.py
@@ -1,13 +1,9 @@
-import os
-
+import config
+from config import MODEL_NAME
 from langchain.agents import create_react_agent, AgentExecutor, create_structured_chat_agent
 from langchain_community.tools.ddg_search import DuckDuckGoSearchRun
 from langchain_core.prompts import PromptTemplate
 from langchain_openai import ChatOpenAI
-
-os.environ["LANGCHAIN_TRACING_V2"] = "true"
-os.environ["LANGCHAIN_API_KEY"] = os.getenv("LS_API_KEY")
-os.environ["LANGCHAIN_PROJECT"] = "Agents"
 
 search = DuckDuckGoSearchRun()
 tools = [search]
@@ -19,7 +15,7 @@ prompt = PromptTemplate.from_template(
     "times)\nThought: I now know the final answer\nFinal Answer: the final answer to the original input "
     "question\n\nBegin!\n\nQuestion: {input}\nThought:{agent_scratchpad}")
 
-llm = ChatOpenAI(model="gpt-3.5-turbo")
+llm = ChatOpenAI(model=MODEL_NAME)
 
 agent = create_react_agent(llm=llm, tools=tools, prompt=prompt)
 

--- a/ReWOO.py
+++ b/ReWOO.py
@@ -1,4 +1,3 @@
-import os
 import re
 import warnings
 from typing import TypedDict, List
@@ -7,11 +6,10 @@ from langchain_community.tools.tavily_search import TavilySearchResults
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
 from langgraph.graph import StateGraph, END
+import config
+from config import BIG_MODEL_NAME
 
 warnings.filterwarnings("ignore")
-os.environ["LANGCHAIN_TRACING_V2"] = "true"
-os.environ["LANGCHAIN_API_KEY"] = os.getenv("LS_API_KEY")
-os.environ["LANGCHAIN_PROJECT"] = "Agents"
 
 
 # Define State
@@ -23,9 +21,7 @@ class ReWOO(TypedDict):
     result: str
 
 
-# llm = ChatOpenAI(model="gpt-3.5-turbo")
-
-big_llm = ChatOpenAI(model="gpt-4-turbo-preview")
+big_llm = ChatOpenAI(model=BIG_MODEL_NAME)
 
 # Planner Node
 prompt = """For the following task, make plans that can solve the problem step by step. For each plan, indicate \

--- a/config.json
+++ b/config.json
@@ -1,0 +1,6 @@
+{
+  "LANGCHAIN_TRACING_V2": true,
+  "LANGCHAIN_PROJECT": "Agents",
+  "MODEL_NAME": "gpt-5-2025-08-07",
+  "BIG_MODEL_NAME": "gpt-5-2025-08-07"
+}

--- a/config.py
+++ b/config.py
@@ -1,0 +1,21 @@
+import json
+import os
+from dotenv import load_dotenv
+
+BASE_DIR = os.path.dirname(__file__)
+load_dotenv()
+
+with open(os.path.join(BASE_DIR, "config.json")) as f:
+    _config = json.load(f)
+
+LANGCHAIN_TRACING_V2 = str(
+    os.getenv("LANGCHAIN_TRACING_V2", _config.get("LANGCHAIN_TRACING_V2", True))
+).lower()
+LANGCHAIN_PROJECT = os.getenv("LANGCHAIN_PROJECT", _config.get("LANGCHAIN_PROJECT", "Agents"))
+MODEL_NAME = os.getenv("MODEL_NAME", _config.get("MODEL_NAME", "gpt-5-2025-08-07"))
+BIG_MODEL_NAME = os.getenv("BIG_MODEL_NAME", _config.get("BIG_MODEL_NAME", MODEL_NAME))
+
+os.environ.setdefault("LANGCHAIN_TRACING_V2", LANGCHAIN_TRACING_V2)
+os.environ.setdefault("LANGCHAIN_PROJECT", LANGCHAIN_PROJECT)
+if os.getenv("LS_API_KEY") and not os.getenv("LANGCHAIN_API_KEY"):
+    os.environ["LANGCHAIN_API_KEY"] = os.getenv("LS_API_KEY")


### PR DESCRIPTION
## Summary
- centralize environment settings in `config.json` and `.env`
- replace legacy gpt-3.5 references with configurable `gpt-5-2025-08-07`
- add reusable `config` module for shared settings
- implement a Magentic One multi-agent flow using AutoGen with planner, researcher, writer, and critic agents
- default to `gpt-5-2025-08-07` for both small and large model settings

## Testing
- `curl https://platform.openai.com/docs/models` *(fails: CONNECT tunnel failed, response 403)*
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_68a44f8b1e9c83289d1f6e67183dfc6a